### PR TITLE
Fix NullPointerException when emptying the recyclerView

### DIFF
--- a/parallaxrecyclerview/src/main/java/com/southernbox/parallaxrecyclerview/ParallaxRecyclerView.java
+++ b/parallaxrecyclerview/src/main/java/com/southernbox/parallaxrecyclerview/ParallaxRecyclerView.java
@@ -73,8 +73,10 @@ public class ParallaxRecyclerView extends RecyclerView {
                 }
 
                 View firstView = layoutManager.findViewByPosition(firstPosition);
-                float firstViewTop = firstView.getTop();
-                firstView.setTranslationY(-firstViewTop / 2.0f);
+                if (firstView != null) {
+                    float firstViewTop = firstView.getTop();
+                    firstView.setTranslationY(-firstViewTop / 2.0f);
+                }
             }
         });
     }


### PR DESCRIPTION
Just a simple fix to this [issue](https://github.com/SouthernBox/ParallaxRecyclerView/issues/1)

